### PR TITLE
Current Spike Method for Mechanism Calibration

### DIFF
--- a/src/main/java/com/team1678/frc2021/Constants.java
+++ b/src/main/java/com/team1678/frc2021/Constants.java
@@ -341,6 +341,7 @@ public class Constants {
 			kHoodServoConstants.kKi = 0;
 			kHoodServoConstants.kKd = 0;
 			kHoodServoConstants.kKf = 0.05;
+			
 			kHoodServoConstants.kMaxIntegralAccumulator = 0;
 			kHoodServoConstants.kIZone = 0; // Ticks
 			kHoodServoConstants.kDeadband = 0; // Ticks

--- a/src/main/java/com/team1678/frc2021/subsystems/Superstructure.java
+++ b/src/main/java/com/team1678/frc2021/subsystems/Superstructure.java
@@ -7,6 +7,7 @@ import com.team1678.frc2021.RobotState;
 import com.team1678.frc2021.loops.ILooper;
 import com.team1678.frc2021.loops.Loop;
 import com.team1678.frc2021.states.SuperstructureConstants;
+import com.team1678.frc2021.subsystems.ServoMotorSubsystem.ControlState;
 import com.team254.lib.geometry.Pose2d;
 import com.team254.lib.geometry.Rotation2d;
 import com.team254.lib.util.InterpolatingDouble;
@@ -254,7 +255,7 @@ public class Superstructure extends Subsystem {
             mTurretSetpoint = 180.0;
         } else if (mWantsTestSpit) {
             mHood.setSetpointMotionMagic(Constants.HoodConstants.kHoodServoConstants.kMinUnitsLimit);
-        } else {
+        } else if (mHood.mControlState != ControlState.OPEN_LOOP) {
             mHood.setSetpointMotionMagic(mHoodSetpoint);
         }
 


### PR DESCRIPTION
- runs mark2 hood down at constant voltage until a current spike limit is registered
- once registered, motor's selected sensor position is calibrated to the hood's minimum limit
- takes away hall effect sensor requirement as long as subsystem has hard stops
- requires current limit and calibrating voltage constants to be found during bring-up